### PR TITLE
Parse images (sitemap extension)

### DIFF
--- a/sitemap.go
+++ b/sitemap.go
@@ -47,6 +47,7 @@ type Entry interface {
 	GetLastModified() *time.Time
 	GetChangeFrequency() Frequency
 	GetPriority() float32
+	GetImage() Image
 }
 
 // IndexEntry is an interface describes an element \ an URL in a sitemap index file.

--- a/sitemap.go
+++ b/sitemap.go
@@ -47,7 +47,7 @@ type Entry interface {
 	GetLastModified() *time.Time
 	GetChangeFrequency() Frequency
 	GetPriority() float32
-	GetImage() Image
+	GetImages() []Image
 }
 
 // IndexEntry is an interface describes an element \ an URL in a sitemap index file.

--- a/sitemap_test.go
+++ b/sitemap_test.go
@@ -125,6 +125,29 @@ func TestParseSitemapIndex(t *testing.T) {
 	}
 }
 
+func TestImages(t *testing.T) {
+	expected := []string{
+		"https://example.com/image.jpg",
+		"https://example.com/photo.jpg",
+		"https://example.com/picture.jpg",
+	}
+	index := 0
+
+	err := ParseFromFile("./testdata/sitemap-image.xml", func(e Entry) error {
+		images := e.GetImages()
+		for _, image := range images {
+			if image.ImageLocation != expected[index] {
+				t.Error(t, "Expected image location %v  but got: %v", expected[index], image.ImageLocation)
+			}
+			index++
+		}
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+}
+
 /*
  * Private API tests
  */

--- a/sitemap_types.go
+++ b/sitemap_types.go
@@ -8,6 +8,12 @@ type sitemapEntry struct {
 	ParsedLastModified *time.Time
 	ChangeFrequency    Frequency `xml:"changefreq,omitempty"`
 	Priority           float32   `xml:"priority,omitempty"`
+	Image              Image     `xml:"image,omitempty"`
+}
+
+type Image struct {
+	ImageLocation string `xml:"loc,omitempty"`
+	ImageTitle    string `xml:"title,omitempty"`
 }
 
 func newSitemapEntry() *sitemapEntry {

--- a/sitemap_types.go
+++ b/sitemap_types.go
@@ -8,7 +8,7 @@ type sitemapEntry struct {
 	ParsedLastModified *time.Time
 	ChangeFrequency    Frequency `xml:"changefreq,omitempty"`
 	Priority           float32   `xml:"priority,omitempty"`
-	Image              Image     `xml:"image,omitempty"`
+	Images             []Image   `xml:"image,omitempty"`
 }
 
 type Image struct {
@@ -22,6 +22,10 @@ func newSitemapEntry() *sitemapEntry {
 
 func (e *sitemapEntry) GetLocation() string {
 	return e.Location
+}
+
+func (e *sitemapEntry) GetImages() []Image {
+	return e.Images
 }
 
 func (e *sitemapEntry) GetLastModified() *time.Time {

--- a/testdata/sitemap-image.xml
+++ b/testdata/sitemap-image.xml
@@ -1,0 +1,20 @@
+<!-- source: https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps -->
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+  <url>
+    <loc>https://example.com/sample1.html</loc>
+    <image:image>
+      <image:loc>https://example.com/image.jpg</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://example.com/photo.jpg</image:loc>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://example.com/sample2.html</loc>
+    <image:image>
+      <image:loc>https://example.com/picture.jpg</image:loc>
+    </image:image>
+  </url>
+</urlset>


### PR DESCRIPTION
Parse images in sitemaps, based on example -> https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps